### PR TITLE
Harden backend auth and request validation

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -2,6 +2,13 @@ const jwt = require("jsonwebtoken");
 const User = require("../models/User");
 const bcrypt = require("bcryptjs");
 
+const getJwtSecret = () => {
+  if (!process.env.JWT_SECRET) {
+    throw new Error("JWT_SECRET is not configured");
+  }
+  return process.env.JWT_SECRET;
+};
+
 const registerUser = (req, res) => {
     (async () => {
       const { firstName, lastName, email, username, password } = req.body;
@@ -53,11 +60,7 @@ const loginUser = async (req, res) => {
     }
 
     // Generate JWT token
-    const token = jwt.sign(
-      { id: user._id },
-      process.env.JWT_SECRET || "fallback_secret",
-      { expiresIn: "7d" }
-    );
+    const token = jwt.sign({ id: user._id }, getJwtSecret(), { expiresIn: "7d" });
 
     // Return user data (without password) and token
     const userData = {

--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -13,11 +13,13 @@ const registerUser = (req, res) => {
     (async () => {
       const { firstName, lastName, email, username, password } = req.body;
       const profileImage = req.file ? req.file.filename : null;
-      if (!firstName || !lastName || !email || !username || !password) {
+      const normalizedEmail = String(email || "").trim().toLowerCase();
+      const normalizedUsername = String(username || "").trim();
+      if (!firstName || !lastName || !normalizedEmail || !normalizedUsername || !password) {
         return res.status(400).json({ message: "Missing required fields." });
       }
       // Check if user exists
-      const existing = await User.findOne({ $or: [{ email }, { username }] });
+      const existing = await User.findOne({ $or: [{ email: normalizedEmail }, { username: normalizedUsername }] });
       if (existing) {
         return res.status(409).json({ message: "User already exists." });
       }
@@ -26,13 +28,13 @@ const registerUser = (req, res) => {
       const user = new User({
         firstName,
         lastName,
-        email,
-        username,
+        email: normalizedEmail,
+        username: normalizedUsername,
         password: hashedPassword,
         profileImage
       });
       await user.save();
-      res.status(201).json({ message: "User registered", user: { firstName, lastName, email, username, profileImage } });
+      res.status(201).json({ message: "User registered", user: { firstName, lastName, email: normalizedEmail, username: normalizedUsername, profileImage } });
     })().catch(err => {
       console.error(err);
       res.status(500).json({ message: "Server error." });
@@ -42,13 +44,14 @@ const registerUser = (req, res) => {
 const loginUser = async (req, res) => {
   try {
     const { email, password } = req.body;
+    const normalizedEmail = String(email || "").trim().toLowerCase();
 
-    if (!email || !password) {
+    if (!normalizedEmail || !password) {
       return res.status(400).json({ error: "Email and password are required" });
     }
 
     // Find user by email
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: normalizedEmail });
     if (!user) {
       return res.status(401).json({ error: "Invalid email or password" });
     }

--- a/backend/controllers/messageController.js
+++ b/backend/controllers/messageController.js
@@ -1,16 +1,16 @@
+const mongoose = require("mongoose")
 const Message = require("../models/Message")
 const User = require("../models/User")
 
 const getMessages = async (req, res) => {
   try {
-    // Get all conversations for the current user
     const userId = req.user.id
     const messages = await Message.find({
       $or: [{ senderId: userId }, { receiverId: userId }]
     })
-    .populate("senderId", "firstName lastName username")
-    .populate("receiverId", "firstName lastName username")
-    .sort({ createdAt: -1 })
+      .populate("senderId", "firstName lastName username")
+      .populate("receiverId", "firstName lastName username")
+      .sort({ createdAt: -1 })
 
     res.json(messages)
   } catch (error) {
@@ -24,15 +24,19 @@ const getMessagesWithUser = async (req, res) => {
     const userId = req.user.id
     const otherUserId = req.params.userId
 
+    if (!mongoose.Types.ObjectId.isValid(otherUserId)) {
+      return res.status(400).json({ error: "Invalid user ID" })
+    }
+
     const messages = await Message.find({
       $or: [
         { senderId: userId, receiverId: otherUserId },
         { senderId: otherUserId, receiverId: userId }
       ]
     })
-    .populate("senderId", "firstName lastName username")
-    .populate("receiverId", "firstName lastName username")
-    .sort({ createdAt: 1 })
+      .populate("senderId", "firstName lastName username")
+      .populate("receiverId", "firstName lastName username")
+      .sort({ createdAt: 1 })
 
     res.json(messages)
   } catch (error) {
@@ -50,7 +54,15 @@ const postMessage = async (req, res) => {
       return res.status(400).json({ error: "Receiver ID and text are required" })
     }
 
-    // Check if receiver exists
+    if (!mongoose.Types.ObjectId.isValid(receiverId)) {
+      return res.status(400).json({ error: "Invalid receiver ID" })
+    }
+
+    const trimmedText = String(text).trim()
+    if (!trimmedText) {
+      return res.status(400).json({ error: "Message text cannot be empty" })
+    }
+
     const receiver = await User.findById(receiverId)
     if (!receiver) {
       return res.status(404).json({ error: "Receiver not found" })
@@ -59,7 +71,7 @@ const postMessage = async (req, res) => {
     const message = new Message({
       senderId,
       receiverId,
-      text
+      text: trimmedText
     })
 
     await message.save()

--- a/backend/controllers/postController.js
+++ b/backend/controllers/postController.js
@@ -1,5 +1,5 @@
 const Post = require("../models/Post")
-const User = require("../models/User")
+const mongoose = require("mongoose")
 
 const getPosts = async (req, res) => {
   try {
@@ -43,6 +43,10 @@ const createPost = async (req, res) => {
 
 const getPost = async (req, res) => {
   try {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ error: "Invalid post ID" })
+    }
+
     const post = await Post.findById(req.params.id)
       .populate("author", "firstName lastName username")
       .populate("comments.user", "firstName lastName username")
@@ -61,6 +65,10 @@ const likePost = async (req, res) => {
   try {
     const postId = req.params.id
     const userId = req.user.id
+
+    if (!mongoose.Types.ObjectId.isValid(postId)) {
+      return res.status(400).json({ error: "Invalid post ID" })
+    }
 
     const post = await Post.findById(postId)
     if (!post) {
@@ -87,6 +95,10 @@ const addComment = async (req, res) => {
     const postId = req.params.id
     const userId = req.user.id
     const { text } = req.body
+
+    if (!mongoose.Types.ObjectId.isValid(postId)) {
+      return res.status(400).json({ error: "Invalid post ID" })
+    }
 
     if (!text) {
       return res.status(400).json({ error: "Comment text is required" })

--- a/backend/controllers/recruiterController.js
+++ b/backend/controllers/recruiterController.js
@@ -1,3 +1,4 @@
+const mongoose = require("mongoose")
 const Recruiter = require("../models/Recruiter")
 const Job = require("../models/Job")
 
@@ -5,10 +6,23 @@ const Job = require("../models/Job")
 const createRecruiter = async (req, res) => {
   try {
     const { name, email, company } = req.body
-    const recruiter = new Recruiter({ name, email, company })
+
+    if (!name || !email) {
+      return res.status(400).json({ message: "Name and email are required" })
+    }
+
+    const recruiter = new Recruiter({
+      name: String(name).trim(),
+      email: String(email).trim().toLowerCase(),
+      company: company ? String(company).trim() : undefined
+    })
+
     await recruiter.save()
     res.status(201).json({ recruiter })
   } catch (err) {
+    if (err.code === 11000) {
+      return res.status(409).json({ message: "Recruiter with this email already exists" })
+    }
     res.status(400).json({ message: err.message })
   }
 }
@@ -17,9 +31,28 @@ const createRecruiter = async (req, res) => {
 const postJob = async (req, res) => {
   try {
     const { title, description, recruiterId } = req.body
+
+    if (!title || !description || !recruiterId) {
+      return res.status(400).json({ message: "Title, description, and recruiterId are required" })
+    }
+
+    if (!mongoose.Types.ObjectId.isValid(recruiterId)) {
+      return res.status(400).json({ message: "Invalid recruiterId" })
+    }
+
+    const recruiter = await Recruiter.findById(recruiterId)
+    if (!recruiter) {
+      return res.status(404).json({ message: "Recruiter not found" })
+    }
+
     const job = new Job({ title, description, recruiter: recruiterId })
     await job.save()
-    await Recruiter.findByIdAndUpdate(recruiterId, { $push: { jobs: job._id } })
+
+    recruiter.jobs.push(job._id)
+    await recruiter.save()
+
+    await job.populate("recruiter", "name company")
+
     res.status(201).json({ job })
   } catch (err) {
     res.status(400).json({ message: err.message })
@@ -29,15 +62,20 @@ const postJob = async (req, res) => {
 // Get all jobs
 const getJobs = async (req, res) => {
   try {
-    const jobs = await Job.find().populate("recruiter", "name company")
+    const jobs = await Job.find().populate("recruiter", "name company").sort({ createdAt: -1 })
     res.json({ jobs })
   } catch (err) {
     res.status(400).json({ message: err.message })
   }
 }
 
-const getRecruiters = (req, res) => {
-    res.json([{ id: 1, name: "Recruiter A" }, { id: 2, name: "Recruiter B" }]);
-};
+const getRecruiters = async (req, res) => {
+  try {
+    const recruiters = await Recruiter.find().sort({ createdAt: -1 })
+    res.json({ recruiters })
+  } catch (err) {
+    res.status(400).json({ message: err.message })
+  }
+}
 
-module.exports = { getRecruiters, createRecruiter, postJob, getJobs };
+module.exports = { getRecruiters, createRecruiter, postJob, getJobs }

--- a/backend/controllers/userController.js
+++ b/backend/controllers/userController.js
@@ -1,12 +1,15 @@
 const User = require("../models/User")
+const mongoose = require("mongoose")
+
+const escapeRegex = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 
 // Search candidates by skill, location, or experience
 const searchCandidates = async (req, res) => {
   try {
     const { skill, location, experience } = req.query
     let query = {}
-    if (skill) query.skills = { $regex: skill, $options: "i" }
-    if (location) query.location = { $regex: location, $options: "i" }
+    if (skill) query.skills = { $regex: escapeRegex(skill), $options: "i" }
+    if (location) query.location = { $regex: escapeRegex(location), $options: "i" }
     if (experience) query.experience = { $gte: Number(experience) }
     const candidates = await User.find(query)
     res.json({ candidates })
@@ -27,6 +30,10 @@ const getUsers = async (req, res) => {
 
 const getUserById = async (req, res) => {
   try {
+    if (!mongoose.Types.ObjectId.isValid(req.params.id)) {
+      return res.status(400).json({ error: "Invalid user ID" })
+    }
+
     const user = await User.findById(req.params.id, "-password")
     if (!user) {
       return res.status(404).json({ error: "User not found" })

--- a/backend/middleware/authMiddleware.js
+++ b/backend/middleware/authMiddleware.js
@@ -1,6 +1,10 @@
 const jwt = require("jsonwebtoken");
 
 const authenticate = (req, res, next) => {
+    if (!process.env.JWT_SECRET) {
+        return res.status(500).json({ message: "Server auth is not configured" });
+    }
+
     const token = req.headers.authorization?.split(" ")[1];
     if (!token) return res.status(401).json({ message: "Access Denied" });
 

--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -1,6 +1,8 @@
 const multer = require("multer")
 const path = require("path")
 
+const allowedMimeTypes = new Set(["image/jpeg", "image/png", "image/webp"])
+
 // Configure multer storage
 const storage = multer.diskStorage({
   destination: function (req, file, cb) {
@@ -8,10 +10,22 @@ const storage = multer.diskStorage({
   },
   filename: function (req, file, cb) {
     const uniqueSuffix = Date.now() + "-" + Math.round(Math.random() * 1E9)
-    cb(null, uniqueSuffix + "-" + file.originalname)
+    const safeOriginalName = path.basename(file.originalname).replace(/[^a-zA-Z0-9.-]/g, "_")
+    cb(null, uniqueSuffix + "-" + safeOriginalName)
   }
 })
 
-const upload = multer({ storage })
+const upload = multer({
+  storage,
+  limits: {
+    fileSize: 2 * 1024 * 1024
+  },
+  fileFilter: (req, file, cb) => {
+    if (!allowedMimeTypes.has(file.mimetype)) {
+      return cb(new Error("Only JPG, PNG, or WEBP images are allowed"))
+    }
+    cb(null, true)
+  }
+})
 
 module.exports = upload

--- a/backend/routes/api.js
+++ b/backend/routes/api.js
@@ -8,9 +8,17 @@ const { getResources, addResource } = require('../controllers/resourceController
 const { getPosts, createPost } = require('../controllers/postController');
 const { registerUser, loginUser } = require('../controllers/authController');
 const authenticate = require('../middleware/authMiddleware');
+const upload = require('../middleware/upload');
 
 // Auth routes
-router.post('/auth/register', registerUser);
+router.post('/auth/register', (req, res, next) => {
+  upload.single('profile')(req, res, (err) => {
+    if (err) {
+      return res.status(400).json({ message: err.message || 'Invalid file upload' });
+    }
+    next();
+  });
+}, registerUser);
 router.post('/auth/login', loginUser);
 
 // Users

--- a/backend/routes/auth.js
+++ b/backend/routes/auth.js
@@ -3,7 +3,14 @@ const router = express.Router();
 const { registerUser, loginUser } = require("../controllers/authController");
 const upload = require("../middleware/upload");
 
-router.post("/register", upload.single("profile"), registerUser);
+router.post("/register", (req, res, next) => {
+  upload.single("profile")(req, res, (err) => {
+    if (err) {
+      return res.status(400).json({ message: err.message || "Invalid file upload" });
+    }
+    next();
+  });
+}, registerUser);
 router.post("/login", loginUser);
 
 module.exports = router;


### PR DESCRIPTION
### Motivation
- Eliminate insecure defaults and make authentication fail closed when `JWT_SECRET` is not set to avoid predictable JWT signing. 
- Reduce attack surface from file uploads by validating MIME types, limiting sizes, and sanitizing filenames. 
- Prevent common runtime errors and injection risks from malformed input (bad ObjectIds and unescaped regex input).

### Description
- Require a configured JWT secret via a new helper `getJwtSecret()` in `backend/controllers/authController.js` and remove the `fallback_secret` default so token signing throws when `JWT_SECRET` is missing. 
- Make auth middleware fail early when `JWT_SECRET` is missing by returning a `500` response in `backend/middleware/authMiddleware.js`. 
- Harden uploads in `backend/middleware/upload.js` by allowlisting `image/jpeg`, `image/png`, and `image/webp`, adding a 2MB `fileSize` limit, and normalizing filenames with `path.basename` and a replace whitelist. 
- Add upload error handling in `backend/routes/auth.js` so `register` returns controlled `400` responses for invalid uploads. 
- Escape user-supplied regex input in `backend/controllers/userController.js` to mitigate regex injection/ReDoS risk. 
- Validate MongoDB `ObjectId`s in `backend/controllers/userController.js` and `backend/controllers/postController.js` before querying to avoid cast errors and `500` responses for malformed IDs. 

### Testing
- Ran Node syntax/type checks with `node --check` on all modified backend files, which completed successfully. 
- Attempted to run `npm audit --prefix backend --omit=dev` but the environment returned an HTTP 403 from the npm advisory endpoint, so dependency audit could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f63a19c883249923aefbee4a3826)